### PR TITLE
Double statusbar margin issue for android users when onboarding

### DIFF
--- a/src/screens/onboarding/OnBoardScreen.js
+++ b/src/screens/onboarding/OnBoardScreen.js
@@ -8,6 +8,8 @@ import Onboarding from 'react-native-onboarding-swiper';
 export default function OnBoardScreen({navigation}) {
     return (
         <Onboarding
+        controlStatusBar={false}
+        containerStyles={{ height: '100%' }}
         SkipButtonComponent={SkipButton}
         NextButtonComponent={NextButton}
         DoneButtonComponent={DoneButton}


### PR DESCRIPTION
Changed Onboarding to remove control statusbar to avoid having margin of 2 x statusBar.height for android users