### PR TITLE
add navigation listeners to chat and message screens

### DIFF
--- a/src/screens/home/ChatScreen.js
+++ b/src/screens/home/ChatScreen.js
@@ -199,13 +199,14 @@ export default function ChatScreen({ route, onPress, navigation }) {
 
                 setMessages(messages);
             });
-        /*
-        navigation.addListener('beforeRemove', (e) => {
+
+        const backNav = navigation.addListener('beforeRemove', (e) => {
             e.preventDefault();
+            backNav();
             toggleHaveNewMessage();
             navigation.goBack();
         });
-        */
+
         // Stop listening for updates whenever the component unmounts
         return () => messagesListener();
     }, []);

--- a/src/screens/home/MessagesScreen.js
+++ b/src/screens/home/MessagesScreen.js
@@ -39,6 +39,12 @@ export default function MessagesScreen({ navigation }) {
         const _unsubscribe = navigation.addListener("focus", () =>
             getThreads()
         );
+        const backNav = navigation.addListener('beforeRemove', (e) => {
+            e.preventDefault();
+            backNav();
+            toggleHaveNewMessage();
+            navigation.goBack();
+        });
 
         return () => {
             _unsubscribe();


### PR DESCRIPTION
backward navigation from chat and message screen sets haveNewMessage to false for user, avoiding the issue where user on either screen receiving a new message causes the alert icon to be shown 