### PR TITLE
UI update when image is present (EditPostScreen)

### DIFF
--- a/src/screens/home/EditPostScreen.js
+++ b/src/screens/home/EditPostScreen.js
@@ -120,12 +120,12 @@ const styles = StyleSheet.create({
   },
   image: {
     width: '100%',
-    height: '50%',
+    height: '40%',
     marginBottom: 15
   },
   input: {
     flex: 0,
-    height: 400,
+    height: 100,
     width: '90%',
     margin: 12,
     borderWidth: 1,


### PR DESCRIPTION
Previous textInput was too big (height was 400) and when we display image with that textInput size, the screen was not able to contain all the components.

Re-adjusted textInput height to 100 which is the same as textInput in AddPostScreen. Also rescaled image height to be 40% of screen height to standardise scaling and UI with AddPostScreen.