### PR TITLE
Added haptic feedback for liking/voting, optional feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-eslint": "^10.1.0",
     "depcheck": "^1.4.1",
     "expo": "~41.0.1",
+    "expo-haptics": "^10.0.0",
     "expo-image-picker": "^10.1.4",
     "expo-notifications": "^0.11.6",
     "expo-permissions": "^12.0.1",

--- a/src/components/ForumPost.js
+++ b/src/components/ForumPost.js
@@ -110,6 +110,7 @@ const ForumPost = ({
       .update({ votes: item.votes })
     setUpvoted(false)
     setDownvoted(true)
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
   }
 
   const unVote = async () => {

--- a/src/components/ForumPost.js
+++ b/src/components/ForumPost.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { MaterialIcons } from 'react-native-vector-icons'
 import { Menu, MenuOptions, MenuOption, MenuTrigger } from 'react-native-popup-menu'
+import * as Haptics from 'expo-haptics'
 
 const ForumPost = ({
   route,
@@ -82,6 +83,7 @@ const ForumPost = ({
       .update({ votes: item.votes })
     setUpvoted(true)
     setDownvoted(false)
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
   }
 
   const downVote = async () => {

--- a/src/components/ForumPost.js
+++ b/src/components/ForumPost.js
@@ -83,7 +83,7 @@ const ForumPost = ({
       .update({ votes: item.votes })
     setUpvoted(true)
     setDownvoted(false)
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
   }
 
   const downVote = async () => {
@@ -110,7 +110,7 @@ const ForumPost = ({
       .update({ votes: item.votes })
     setUpvoted(false)
     setDownvoted(true)
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
   }
 
   const unVote = async () => {

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -20,6 +20,7 @@ import {
 import ProgressiveImage from './ProgressiveImage'
 import DoubleTap from './DoubleTap'
 import { sendPushNotification } from '../api/notifications'
+import * as Haptics from 'expo-haptics'
 
 const PostCard = ({
   route,
@@ -118,6 +119,7 @@ const PostCard = ({
         .update({ likeCount: item.likeCount })
       console.log('Like')
       setUserLiked(true)
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
 
       firebase.firestore().collection('users').doc(item.userId).get()
         .then((doc) => {

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -119,7 +119,7 @@ const PostCard = ({
         .update({ likeCount: item.likeCount })
       console.log('Like')
       setUserLiked(true)
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
 
       firebase.firestore().collection('users').doc(item.userId).get()
         .then((doc) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4841,6 +4841,11 @@ expo-font@~9.1.0:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-haptics@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/expo-haptics/-/expo-haptics-10.0.0.tgz#a2dba3995fab4774747d9f7c2b021accf9afc061"
+  integrity sha512-dfl4Fef22B8O49x5JEzILmAhathT14bkN0kic2FpuwssJDX/yZ/R2lD12Iu9XqxdgHAFQRjOSq3dFjrxDGkP6g==
+
 expo-image-picker@^10.1.4:
   version "10.1.4"
   resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-10.1.4.tgz#5805ea365385298cd59315790481a0a8d6c6a9ef"


### PR DESCRIPTION
Taking reference from social media like Instagram, liking a post usually offers the user some haptic feedback. This PR implements haptic feedback for liking a user post and voting on a portal post. This is an optional feature, left open for discussion